### PR TITLE
Add support to python 3.8 and 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.11"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 name = "cloud-storage-mocker"
 description = "Mocker library of Google Cloud Storage with local filesystem mounting."
 readme = "README.md"
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.8, <3.13"
 license = {text = "MIT License"}
 authors = [
     {name = "Yusuke Oda", email = "odashi@inspiredco.ai"}
@@ -22,6 +22,8 @@ keywords = [
 ]
 classifiers = [
     "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/src/cloud_storage_mocker/_core.py
+++ b/src/cloud_storage_mocker/_core.py
@@ -1,5 +1,7 @@
 """Core implementation."""
 
+from __future__ import annotations 
+
 import contextlib
 import dataclasses
 import io

--- a/src/cloud_storage_mocker/_core.py
+++ b/src/cloud_storage_mocker/_core.py
@@ -1,6 +1,6 @@
 """Core implementation."""
 
-from __future__ import annotations 
+from __future__ import annotations
 
 import contextlib
 import dataclasses

--- a/src/cloud_storage_mocker/_core_test.py
+++ b/src/cloud_storage_mocker/_core_test.py
@@ -1,6 +1,6 @@
 """Tests for cloud_storage_mocker._core."""
 
-from __future__ import annotations 
+from __future__ import annotations
 
 import pathlib
 from unittest import mock

--- a/src/cloud_storage_mocker/_core_test.py
+++ b/src/cloud_storage_mocker/_core_test.py
@@ -1,5 +1,7 @@
 """Tests for cloud_storage_mocker._core."""
 
+from __future__ import annotations 
+
 import pathlib
 from unittest import mock
 


### PR DESCRIPTION
Great package! Can we add support for python 3.8 and 3.9? Hopefully this should work. My local PR is passing the build: https://github.com/Bougeant/cloud-storage-mocker/pull/1

Sorry for the bad branch and commit names, I did this from the github UI.